### PR TITLE
chore(tests): clear MSW warnings

### DIFF
--- a/src/lib/english-heritage/get-places.unit.test.ts
+++ b/src/lib/english-heritage/get-places.unit.test.ts
@@ -1,10 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getPlaces } from "./get-places";
 import { englishHeritageMockServer } from "test/mocks/english-heritage/server";
+import { EH_BASE_URL } from "./constants";
 
 describe("getPlaces", () => {
 	beforeAll(() => {
-		englishHeritageMockServer.listen();
+		englishHeritageMockServer.listen({
+			onUnhandledRequest: ({ url }) => {
+				if (!url.startsWith(EH_BASE_URL)) return;
+			},
+		});
 	});
 
 	afterAll(() => {

--- a/src/lib/english-heritage/get-places.unit.test.ts
+++ b/src/lib/english-heritage/get-places.unit.test.ts
@@ -1,19 +1,17 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getPlaces } from "./get-places";
-import { englishHeritageMockServer } from "test/mocks/english-heritage/server";
-import { EH_BASE_URL } from "./constants";
+import {
+	startEnglishHeritageMockServer,
+	stopEnglishHeritageMockServer,
+} from "test/mocks/english-heritage/server";
 
 describe("getPlaces", () => {
 	beforeAll(() => {
-		englishHeritageMockServer.listen({
-			onUnhandledRequest: ({ url }) => {
-				if (!url.startsWith(EH_BASE_URL)) return;
-			},
-		});
+		startEnglishHeritageMockServer();
 	});
 
 	afterAll(() => {
-		englishHeritageMockServer.close();
+		stopEnglishHeritageMockServer();
 	});
 
 	it("should fetch places data", async () => {

--- a/src/lib/english-heritage/upsert-places.integration.test.ts
+++ b/src/lib/english-heritage/upsert-places.integration.test.ts
@@ -2,20 +2,18 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { upsertPlaces } from "./upsert-places";
 import { db } from "@/db";
 import { places } from "@/db/schema";
-import { englishHeritageMockServer } from "test/mocks/english-heritage/server";
-import { EH_BASE_URL } from "./constants";
+import {
+	startEnglishHeritageMockServer,
+	stopEnglishHeritageMockServer,
+} from "test/mocks/english-heritage/server";
 
 describe("upsertPlaces", () => {
 	beforeAll(() => {
-		englishHeritageMockServer.listen({
-			onUnhandledRequest: ({ url }) => {
-				if (!url.startsWith(EH_BASE_URL)) return;
-			},
-		});
+		startEnglishHeritageMockServer();
 	});
 
 	afterAll(() => {
-		englishHeritageMockServer.close();
+		stopEnglishHeritageMockServer();
 	});
 
 	it("Should get places data and add it to the database", async () => {

--- a/src/lib/english-heritage/upsert-places.integration.test.ts
+++ b/src/lib/english-heritage/upsert-places.integration.test.ts
@@ -3,10 +3,15 @@ import { upsertPlaces } from "./upsert-places";
 import { db } from "@/db";
 import { places } from "@/db/schema";
 import { englishHeritageMockServer } from "test/mocks/english-heritage/server";
+import { EH_BASE_URL } from "./constants";
 
 describe("upsertPlaces", () => {
 	beforeAll(() => {
-		englishHeritageMockServer.listen();
+		englishHeritageMockServer.listen({
+			onUnhandledRequest: ({ url }) => {
+				if (!url.startsWith(EH_BASE_URL)) return;
+			},
+		});
 	});
 
 	afterAll(() => {

--- a/src/lib/national-trust/constants.ts
+++ b/src/lib/national-trust/constants.ts
@@ -1,0 +1,1 @@
+export const NT_BASE_URL = "https://www.nationaltrust.org.uk";

--- a/src/lib/national-trust/get-places.ts
+++ b/src/lib/national-trust/get-places.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { NTPlaceSchema } from "./types/place";
+import { NT_BASE_URL } from "./constants";
 
 export const NTPlacesResultSchema = z.object({
 	multiMatch: z.object({
@@ -13,7 +14,7 @@ export type NTPlacesResult = z.infer<typeof NTPlacesResultSchema>;
 
 export async function getPlaces(): Promise<NTPlacesResult> {
 	const response = await fetch(
-		"https://www.nationaltrust.org.uk/api/search/places?query=&lat=52&lon=0&milesRadius=1000&maxPlaceResults=1000",
+		`${NT_BASE_URL}/api/search/places?query=&lat=52&lon=0&milesRadius=1000&maxPlaceResults=1000`,
 	);
 	if (!response.ok) {
 		throw new Error("Network response was not ok");

--- a/src/lib/national-trust/get-places.unit.test.ts
+++ b/src/lib/national-trust/get-places.unit.test.ts
@@ -1,10 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getPlaces } from "./get-places";
 import { nationalTrustMockServer } from "../../../test/mocks/national-trust/server";
+import { NT_BASE_URL } from "./constants";
 
 describe("getPlaces", () => {
 	beforeAll(() => {
-		nationalTrustMockServer.listen();
+		nationalTrustMockServer.listen({
+			onUnhandledRequest: ({ url }) => {
+				if (!url.startsWith(NT_BASE_URL)) return;
+			},
+		});
 	});
 
 	afterAll(() => {

--- a/src/lib/national-trust/get-places.unit.test.ts
+++ b/src/lib/national-trust/get-places.unit.test.ts
@@ -1,19 +1,17 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getPlaces } from "./get-places";
-import { nationalTrustMockServer } from "../../../test/mocks/national-trust/server";
-import { NT_BASE_URL } from "./constants";
+import {
+	startNationalTrustMockServer,
+	stopNationalTrustMockServer,
+} from "test/mocks/national-trust/server";
 
 describe("getPlaces", () => {
 	beforeAll(() => {
-		nationalTrustMockServer.listen({
-			onUnhandledRequest: ({ url }) => {
-				if (!url.startsWith(NT_BASE_URL)) return;
-			},
-		});
+		startNationalTrustMockServer();
 	});
 
 	afterAll(() => {
-		nationalTrustMockServer.close();
+		stopNationalTrustMockServer();
 	});
 
 	it("should fetch places data", async () => {

--- a/src/lib/national-trust/upsert-places.integration.test.ts
+++ b/src/lib/national-trust/upsert-places.integration.test.ts
@@ -1,21 +1,19 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { upsertPlaces } from "./upsert-places";
-import { nationalTrustMockServer } from "test/mocks/national-trust/server";
 import { db } from "@/db";
 import { places } from "@/db/schema";
-import { NT_BASE_URL } from "./constants";
+import {
+	startNationalTrustMockServer,
+	stopNationalTrustMockServer,
+} from "../../../test/mocks/national-trust/server";
 
 describe("upsertPlaces", () => {
 	beforeAll(() => {
-		nationalTrustMockServer.listen({
-			onUnhandledRequest: ({ url }) => {
-				if (!url.startsWith(NT_BASE_URL)) return;
-			},
-		});
+		startNationalTrustMockServer();
 	});
 
 	afterAll(() => {
-		nationalTrustMockServer.close();
+		stopNationalTrustMockServer();
 	});
 
 	it("Should get places data and add it to the database", async () => {

--- a/src/lib/national-trust/upsert-places.integration.test.ts
+++ b/src/lib/national-trust/upsert-places.integration.test.ts
@@ -3,10 +3,15 @@ import { upsertPlaces } from "./upsert-places";
 import { nationalTrustMockServer } from "test/mocks/national-trust/server";
 import { db } from "@/db";
 import { places } from "@/db/schema";
+import { NT_BASE_URL } from "./constants";
 
 describe("upsertPlaces", () => {
 	beforeAll(() => {
-		nationalTrustMockServer.listen();
+		nationalTrustMockServer.listen({
+			onUnhandledRequest: ({ url }) => {
+				if (!url.startsWith(NT_BASE_URL)) return;
+			},
+		});
 	});
 
 	afterAll(() => {

--- a/test/mocks/english-heritage/server.ts
+++ b/test/mocks/english-heritage/server.ts
@@ -1,6 +1,17 @@
 import { setupServer } from "msw/node";
 import { placesHandler } from "./places-handler";
+import { EH_BASE_URL } from "@/lib/english-heritage/constants";
 
 const handlers = [placesHandler];
 
-export const englishHeritageMockServer = setupServer(...handlers);
+const englishHeritageMockServer = setupServer(...handlers);
+
+export const startEnglishHeritageMockServer = () =>
+	englishHeritageMockServer.listen({
+		onUnhandledRequest: ({ url }) => {
+			if (!url.startsWith(EH_BASE_URL)) return;
+		},
+	});
+
+export const stopEnglishHeritageMockServer = () =>
+	englishHeritageMockServer.close();

--- a/test/mocks/english-heritage/server.ts
+++ b/test/mocks/english-heritage/server.ts
@@ -8,8 +8,9 @@ const englishHeritageMockServer = setupServer(...handlers);
 
 export const startEnglishHeritageMockServer = () =>
 	englishHeritageMockServer.listen({
-		onUnhandledRequest: ({ url }) => {
+		onUnhandledRequest: ({ url }, print) => {
 			if (!url.startsWith(EH_BASE_URL)) return;
+			print.error();
 		},
 	});
 

--- a/test/mocks/national-trust/places-handler.ts
+++ b/test/mocks/national-trust/places-handler.ts
@@ -1,8 +1,9 @@
 import { http, HttpResponse } from "msw";
 import placesJson from "./places.json";
+import { NT_BASE_URL } from "@/lib/national-trust/constants";
 
 export const placesHandler = http.get(
-	"https://www.nationaltrust.org.uk/api/search/places",
+	`${NT_BASE_URL}/api/search/places`,
 	() => {
 		return HttpResponse.json(placesJson);
 	},

--- a/test/mocks/national-trust/server.ts
+++ b/test/mocks/national-trust/server.ts
@@ -1,6 +1,18 @@
 import { setupServer } from "msw/node";
 import { placesHandler } from "./places-handler";
+import { NT_BASE_URL } from "@/lib/national-trust/constants";
 
 const handlers = [placesHandler];
 
-export const nationalTrustMockServer = setupServer(...handlers);
+const nationalTrustMockServer = setupServer(...handlers);
+
+export const startNationalTrustMockServer = () =>
+	nationalTrustMockServer.listen({
+		onUnhandledRequest: ({ url }, print) => {
+			if (!url.startsWith(NT_BASE_URL)) return;
+			print.error();
+		},
+	});
+
+export const stopNationalTrustMockServer = () =>
+	nationalTrustMockServer.close();


### PR DESCRIPTION
Handle unhandled requests by checking if they match the start of the respective URLS on the mock server